### PR TITLE
Update HomeInfo.mdx

### DIFF
--- a/website/src/components/HomepageContent/HomeInfo.mdx
+++ b/website/src/components/HomepageContent/HomeInfo.mdx
@@ -40,7 +40,7 @@ PURL simplifies tooling development, automation, and integration for
 tasks such as software composition analysis, vulnerability management,
 and license compliance.
 
-See the [PURL](https://package-url.github.io/www.packageurl.org/docs/purl/purl-spec-introduction) 
+See the [PURL](docs/purl/purl-spec-introduction) 
 section of this website for details about:
 - The PURL specification
 - How to build, parse or test a PURL
@@ -74,7 +74,7 @@ version range notation with a predictable structure.
 VERS simplifies tooling development, automation, and integration for tasks 
 such as software composition analysis and software vulnerability management.
 
-See the [VERS](https://package-url.github.io/www.packageurl.org/docs/vers-spec/vers-spec-introduction) 
+See the [VERS](docs/vers-spec/vers-spec-introduction)
 section of this website for details about:
 - The VERS specification
 - How to parse and validate a VERS


### PR DESCRIPTION
Replaced the PURL specific Introduction (copy of `purl-spec/docs/standard/introduction.md`)with new sections that cover both  PURL and VERS. 