### PR TITLE
Update section titles and descriptions #86

### DIFF
--- a/website/docs/purl/purl-spec-adopters.md
+++ b/website/docs/purl/purl-spec-adopters.md
@@ -1,3 +1,4 @@
 # Adopters
 
-Please refer to the [Software Specifications and Tools](/#software-specifications-and-tools) section on the home page for details.
+Please refer to the [Specifications and Tools](/#specifications-and-tools)
+section on the home page for details.

--- a/website/docs/vers-spec/vers-spec-adopters.md
+++ b/website/docs/vers-spec/vers-spec-adopters.md
@@ -1,4 +1,5 @@
 # Adopters
 
-Please refer to the [Software Specifications and Tools](/#software-specifications-and-tools) section 
-on the home page for information about the specifications that have adopted VERS.
+Please refer to the [Specifications and Tools](/#specifications-and-tools)
+section on the home page for information about the specifications that have
+adopted VERS.

--- a/website/src/components/HomepageContent/index.js
+++ b/website/src/components/HomepageContent/index.js
@@ -25,12 +25,12 @@ export default function HomepageContent() {
                     className={styles.sectionHeader}
                     style={{ marginBottom: '15px' }}
                 >
-                    <h1 id='software-specifications-and-tools'>
-                        Software Specifications and Tools
+                    <h1 id='specifications-and-tools'>
+                        Specifications and Tools
                     </h1>
                 </div>
                 <div className={styles.sectionHeader}>
-                    <h2>PURL Adoption - Specifications</h2>
+                    <h2 id="specifications">Specifications</h2>
                 </div>
                 <div
                     className={styles.sectionIntro}
@@ -43,13 +43,14 @@ export default function HomepageContent() {
 
             <section className={styles.sectionContainer}>
                 <div className={styles.sectionHeader}>
-                    <h2>Software Tools</h2>
+                    <h2 id="tools">Tools</h2>
                 </div>
                 <div
                     className={styles.sectionIntro}
                 >
-                    These are community-maintained tools that support or use the
-                    Package-URL (PURL) or VERS standards.
+                    {/* These are community-maintained tools that support or use the
+                    Package-URL (PURL) or VERS standards. */}
+                    These are tools that support or use PURL or VERS.
                 </div>
                 <ToolGrid />
             </section>

--- a/website/src/components/HomepageContent/styles.module.css
+++ b/website/src/components/HomepageContent/styles.module.css
@@ -28,6 +28,11 @@
     color: #992600;
 }
 
+.sectionHeader h1,
+.sectionHeader h2 {
+    scroll-margin-top: 5rem; /* adjust to navbar height */
+}
+
 .sectionContainer {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
- Also added simplified anchors for future linking:
  - Specifications and Tools: 'specifications-and-tools'
  - Specifications: 'specifications'
  - Tools: 'tools'

Reference: https://github.com/package-url/www.packageurl.org/issues/86