### PR TITLE
Update version schemes to vers types

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 This is the repository for the Package-URL public website. It is based on
 [Docusaurus](https://docusaurus.io/docs).
-This website is currently in an Alpha phase with the primary focus on content
+This website is currently in a Beta phase with the primary focus on content
 over format.
 
 We value contributions from members of the community.  You can always suggest
@@ -30,7 +30,7 @@ The "staging" version of the website is at: https://package-url.github.io/www.pa
 The website structure necessarily follows a Docusaurus template and
 configuration. There are two primary ways to update the website:
 - Many elements of the website -- including the navbar, the footer, the
-  sidebars, the home/anding page -- are complex to update.
+  sidebars, the home/landing page -- are complex to update.
     - For these website elements you should create an issue and the core team
       will create the PR or help you create one.
 - Most of the primary website content is composed of markdown files which are
@@ -94,7 +94,7 @@ Looking at the links in the website's navbar (defined in `../website/docusaurus.
             - *Core Specification*: `..website/docs/vers/specification.md`
             - *How to parse and validate VERS*: `..website/docs/vers/how-to-parse.md`
             - *VERS test overview*: `..website/docs/vers/tests.md`
-        - *Version schemes*: `..website/docs/vers/version-schemes.md`
+        - *VERS types*: `..website/docs/vers/vers-types.md`
         - *Schemas*: `..website/docs/vers/schemas.md`
         - *FAQ*: `..website/docs/vers/faq.md`
 

--- a/website/docs/vers/how-to-parse.md
+++ b/website/docs/vers/how-to-parse.md
@@ -17,50 +17,50 @@ To parse a VERS string:
     - Tools shall validate that the URI-scheme value is 'vers'.
 - The right hand side is the specifier.
 - Split the specifier from left once on a slash '/'.
-- The left hand side is the **version-scheme** that shall be
-  lowercase. Tools should validate that the **version-scheme** is a
+- The left hand side is the VERS **type** that shall be
+  lowercase. Tools should validate that the VERS **type** is a
   known scheme.
 - The right hand side is a list of one or more constraints. Tools
-  validate that this **version-constraints** string is not empty
+  validate that this VERS *constraints** string is not empty
   ignoring spaces.
-- If the string is equal to '\*', the **version-constraints** value is
+- If the string is equal to '\*', the **constraints** value is
  '*'. Parsing is done and no further processing is needed for this VERS.
   A tool should report an error if there are characters other than '\*'.
 - Strip leading and trailing pipes '|' from the constraints string.
-- Split the constraints on pipe '|'. The result is a list of
-  **version-constraints** strings. Consecutive pipes shall be treated as one.
+- Split the constraints on pipe '|'. The result is a list of VERS
+  **constraints** strings. Consecutive pipes shall be treated as one.
   Leading and trailing pipes are ignored.
-- For each **version-constraints** string:
-    - Determine if the **version-constraints** string starts with a valid
+- For each VERS **constraints** string:
+    - Determine if the **constraints** string starts with a valid
       **comparator**:  '>=', '<=', '!=', '<', '>', '=', or '*'.
-    - If the **version-constraints** string does not start with a valid
+    - If the **constraints** string does not start with a valid
       **comparator**, then report an error.
-    - If the **comparator** is one of: '>=', '<=', '!=', '<', or '>', then remove
-      the comparator from **version-constraints** string start. The remaining
+    - If the **comparator** is one of: '>=', '<=', '!=', '<', or '>', then 
+      remove the comparator from **constraints** string start. The remaining
       string is the version.
-    - Otherwise the version is the full **version-constraints** string
+    - Otherwise the version is the full **constraints** string
       (which implies an equality comparator of '=').
     - Tools should validate and report an error if the version is
       empty.
     - If the version contains a percent '%' character, apply URL
       quoting rules to unquote this string.
-    - Append the parsed **version-constraints** strings to the
+    - Append the parsed **constraints** strings to the
       constraints list.
 
 Finally:
 
-- The results are the **version-scheme** and the list of
-  **version-constraints** strings.
+- The results are the VERS **type** and the list of **constraints** strings.
 
-Tools should optionally validate and simplify the list of
-**version-contraints** strings once parsing is complete by:
+Tools should optionally validate and simplify the list of VERS
+**contraints** strings once parsing is complete by:
 
 - Sorting and validating the list of constraints
 - Simplifying the list of constraints
 
-### Version-constraints simplification
+### VERS constraints simplification
 
-Tools can simplify a list of **version-constraints** strings using the following approach.
+Tools can simplify a list of **constraints** strings using the following 
+approach.
 
 These pairs of contiguous constraints with these **comparators** are valid:
 
@@ -68,7 +68,9 @@ These pairs of contiguous constraints with these **comparators** are valid:
 - '=', '<', or '<=' followed by '=', '!=', '>', or '>='
 - '>', or '>=' followed by '!=', '<', or '<='
 
-These pairs of contiguous constraints with these **comparators** are redundant and invalid (ignoring any instances of '!=' because they can show up anywhere):
+These pairs of contiguous constraints with these **comparators** are redundant
+ and invalid (ignoring any instances of '!=' because they can show up 
+ anywhere):
 
 - '=', '<' or '<=' followed by '<' or '<=:' this is the same as '<' or '<='
 - '>' or '>=' followed by '=', '>' or '>=:' this is the same as '>' or '>='
@@ -118,12 +120,12 @@ To check if a "tested version" is contained within a version range:
 
 - Start from a parsed version range specifier with:
 
-    - a **version-scheme**
+    - a VERS **type**
     - a list of constraints of **comparator** and **version**, sorted by
       version and where each version occurs only once in any
       constraint.
 
-- If the constraint list contains only one item and the comparator is
+- If the constraints list contains only one item and the comparator is
   '*', then the "tested version" is IN the range. Check is finished.
 
 - Select the version equality and comparison procedures suitable for
@@ -171,11 +173,11 @@ To check if a "tested version" is contained within a version range:
 ### Notes and caveats
 
 - Comparing versions from VERS notations with a different
-  **version-scheme** is an error. Even though there may be some
+  VERS **type** is an error. Even though there may be some
   similarities between the "semver" version for an "npm" and the
   "deb" version for its Debian packaging, the way versions are
-  compared for each **version-scheme** may be different. Tools should
+  compared for each **type** may be different. Tools should
   report an error in this case.
 - All references to sorting or ordering of version constraints mean
   sorting by version. And sorting by versions always implies using the
-  **version-scheme**-specified version comparison and ordering.
+  **type**-specified version comparison and ordering.

--- a/website/docs/vers/introduction.md
+++ b/website/docs/vers/introduction.md
@@ -18,14 +18,17 @@ vulnerable package version ranges means that these ranges may be ambiguous
 or hard to compute and may be replaced by complete enumerations of all
 impacted versions. Expressing and resolving a version range is often a complex
 and error prone task because of the ambiguity and the use of enumerations of
-impacted versions is an appproach that may require frequent updates. A version
-range is a necessary, compact, and practical way to reference multiple versions rather than listing all versions.
+impacted versions is an approach that may require frequent updates. A version
+range is a necessary, compact, and practical way to reference multiple 
+versions rather than listing all versions.
 
 VErsion Range Specifier (VERS) introduces a standard URI-based syntax to
 define package version ranges and the semantics (algorithm or procedure) to
-interpret each version range notation. This standardization provides more accurate and consistent analysis of package version dependencies and the
+interpret each version range notation. This standardization provides more 
+accurate and consistent analysis of package version dependencies and the
 impact of known vulnerabilities or bugs on a package. VERS was developed in
-concert with the Package-URL (PURL) specification standardized with [ECMA-427](https://ecma-tc54.github.io/ECMA-427/).
+concert with the Package-URL (PURL) specification standardized with 
+[ECMA-427](https://ecma-tc54.github.io/ECMA-427/).
 
 Challenges addressed by VERS:
 - **Ambiguity of package dependencies**: With diverse version range notations

--- a/website/docs/vers/specification-folder.md
+++ b/website/docs/vers/specification-folder.md
@@ -15,7 +15,7 @@ The key elements of the current VERS specification are:
 specification for VErsion Range Specifier.
 - **How to parse and validate VERS**: Instructions for validating and parsing
 a VERS.
-- **Version schemes**: Summary of **version-schemes** for many package
+- **Version types**: Summary of VERS **types** for many package
 ecosystems and vulnerability databases.
 - **VERS test schema**: [VERS Test JSON Schema](/docs/vers/schemas) documents
 nine VERS 'test_types' for use by tools that implement VERS.

--- a/website/docs/vers/specification.md
+++ b/website/docs/vers/specification.md
@@ -5,12 +5,12 @@ sidebar_label: Core Specification
 hide_table_of_contents: false
 ---
 
-# Core specification
+# VERS specification
 
 VERS stands for "VErsion Range Specifier. A VERS is an ASCII URI string composed of
 three components:
 
-    scheme:version-scheme/version-constraints|
+    scheme:type/constraints|
 
 Components are separated by a specific character for unambiguous parsing.
 
@@ -19,15 +19,14 @@ Components are separated by a specific character for unambiguous parsing.
 | Component           | Requirement | Description|
 | ------------------- | ----------- |:------------------------------------------------------ |
 | scheme              | Required    | The URL scheme with the constant value of "vers". |
-| version-scheme      | Required    | The version specification or "scheme" such as "semver", "npm", "deb", etc. |
-| version-constraints | Required    | Version constraints may be repeated as many times as needed to accurately reflect the intended range. The separator between version-constraints is a single pipe '\|'. |
+| type                | Required    | The version specification type such as "semver", "npm", "deb", etc. |
+| constraints         | Required    | Version constraints may be repeated as many times as needed to accurately reflect the intended range. The separator between version-constraints is a single pipe '\|'. |
 
 ## Separator characters
 This is how each of the Separator Characters is used:
-- ':' (colon) is the separator between **scheme** and **version-scheme**
-- '/' (slash) is the separator between **version-scheme** and
-**version-constraints**
-- '|' (pipe) is the separator between **version-constraints**
+- ':' (colon) is the separator between **scheme** and **type**
+- '/' (slash) is the separator between **type** and **constraints**
+- '|' (pipe) is the separator between **constraints**
 
 **Example 1 (Informative): npm**
 
@@ -39,7 +38,7 @@ This is how each of the Separator Characters is used:
 
 ## A VERS is a URI scheme
 
-A VERS is a valid URI scheme that conforms to URI definitions or
+A VERS is a valid URI scheme that conforms to URI definitions or 
 specifications at: - https://tools.ietf.org/html/rfc3986
 
 ## VERS components
@@ -48,48 +47,48 @@ specifications at: - https://tools.ietf.org/html/rfc3986
 - The **scheme** is a constant with the value "vers".
 - The **scheme** shall be followed by an unencoded colon ':'.
 
-### Version-scheme
-- The **version-scheme** shall be composed only of ASCII letters and numbers,
+### Type
+- The **type** shall be composed only of ASCII letters and numbers,
   period '.', and dash '-'.
-- The **version-scheme** shall start with an ASCII letter.
-- The **version-scheme** shall not be percent-encoded.
-- The **version-scheme** is case insensitive. The canonical form is lowercase.
-- The **version-scheme** shall be followed by a slash '/'.
+- The **type** shall start with an ASCII letter.
+- The **type** shall not be percent-encoded.
+- The **type** is case insensitive. The canonical form is lowercase.
+- The **type** shall be followed by a slash '/'.
 
-A **version-scheme** defines:
+A **type** defines:
 
-- the specific notation and conventions used for a version string encoded in
-this scheme
-- how two versions are compared to determine if a version is inside or
+- the specific notation and conventions used for a version string encoded 
+according to this type
+- how two versions are compared to determine if a version is inside or 
 outside a range
-- how a version-scheme-specific range notation can be transformed into VERS
+- how a type-specific range notation can be transformed into VERS 
 notation
 
-A **version-scheme** also defines:
+A **type** also defines:
 - how to compare two version strings using **comparators**
 - the structure (if any) of a **version** string such as "1.2.3". For
-example, the "semver" specification for version numbers defines a version as
-composed primarily of three dot-separated numeric segments named "major",
+example, the "semver" specification for version numbers defines a version as 
+composed primarily of three dot-separated numeric segments named "major", 
 "minor" and "patch".
 
-By convention a **version-scheme** should be the same as the
+By convention a **type** should be the same as the
 PURL **type** for a given package ecosystem. It is, however, allowed to
-define a **version-scheme** that does not match an existing PURL **type**
+define a **type** that does not match an existing PURL **type**
 such as a scheme that applies to a single package or project.
 
-### Version-constraints
-- The **version-constraints** component shall be preceded by an unencoded
+### constraints
+- The **constraints** component shall be preceded by an unencoded
 '/' slash separator when not empty.
-- Each instance of the **version-constraints** component is composed of either
+- Each instance of the **constraints** component is composed of either
 a single **version** as in '1.2.3' or the combination of a **comparator** and
 a **version** as in '>=2.0.0'.
 - A **comparator** always precedes the **version** with no characters allowed
 between the **comparator** and the **version**
-- Multiple **version-constraints** strings shall be separated by an unencoded
+- Multiple **constraints** strings shall be separated by an unencoded
 pipe '|'. The pipe "|" has no special meaning other than being a separator.
 
 #### Comparator characters
-A **comparator** is composed of these ASCII characters:
+A **comparator** is composed of these ASCII characters: 
 - the Equals character: '=' (equals, '=')
 - the Not Equals character: '!' (exclamation mark, '!')
 - the Greater Than character: '>' (greater than, '>')
@@ -103,7 +102,7 @@ the provided version.
 equal to the provided version and it must be excluded from the range.
 For example: '!=1.2.3' means that version   "1.2.3" is excluded.
 - '<' is the Less-than **comparator**. This includes all versions less than
-the provided version.
+the provided version. 
 - '<=': is the Less-or-equal **comparator**. This includes all versions less
 than or equal to the provided version. For example '<=1.2.3' means
 less than or equal to "1.2.3".
@@ -120,49 +119,52 @@ Debian package. This includes past, current and possible future versions.
 #### Version strings
 A Version is an ASCII string.
 
-A single **version** in a **version-constraints** string means that a version
-equal to this version satisfies the range specification. Equality is based on
+A single **version** in a **constraints** string means that a version 
+equal to this version satisfies the range specification. Equality is based on 
 the equality of two normalized version strings according to the applicable
-**version-scheme**. For most schemes, this is a simple string equality. A
-**version-scheme** may, however, define normalization and other rules for
+**type**. For most schemes, this is a simple string equality. A 
+**type** may, however, define normalization and other rules for 
 equality such as the "pypi" rules from PEP 440.
 
-A package version satisfies a set of **version-constraints** if it is
-contained within any of the intervals defined by the **version-constraints**.
+A package version satisfies a set of **constraints** if it is 
+contained within any of the intervals defined by the **constraints**.
 
 ## Normalized, canonical representation and validation
 
 VERS construction and validation rules are designed such that a VERS is
 easy to read and understand by humans and straightforward to process
-with tools. The rules are designed to prevent the creation of empty or
+with tools. The rules are designed to prevent the creation of empty or 
 impossible version ranges.
 
-- Spaces are not significant and are removed in a canonical form. For
-example '|<1.2.3|>=2.0|' and '|< 1 . 2 . 3 | > = 2 . 0 |' are equivalent.
+- A VERS string shall already be in canonical form. Non-canonical 
+(unnormalized) forms are invalid and tools shall report an error instead of 
+normalizing them automatically.
 - A version range specifier contains only printable ASCII letters,
 digits and punctuation.
-- The VERS **scheme** and **version-scheme** are always lowercase as in
+- ASCII whitespace is not permitted in a VERS string. Tools shall report an
+error if any Whitespace character, for example SPACE (0x20), TAB (0x09), or 
+LF (0x0A), is used.
+- The VERS **scheme** and **type** are always lowercase as in
 'vers:npm'.
-- Versions are case-sensitive. A **version-scheme** may specify
+- Versions are case-sensitive. A **type** may specify
 its own case sensitivity.
-- If a version in a **version-constraints** string contains **separator** or
+- If a version in a **constraints** string contains **separator** or
 **comparator** characters (i.e., '>', '<', '=', '!', '*', '|'), the version
 shall be quoted using the URL quoting rules. This should be rare in practice.
 
-The list of **version-constraints** strings for a range are like a set of
-signposts in the version timeline of a package. The separators do not mean
-"and" or "or". They are separators in a sequence of **version-constraints**.
+The list of **constraints** strings for a range are like a set of 
+signposts in the version timeline of a package. The separators do not mean 
+"and" or "or". They are separators in a sequence of **constraints**.
 
-With a few simple validation
-rules, we can avoid the creation of most empty or impossible version ranges.
-These rules are:
+With a few simple validation rules, we can avoid the creation of most empty or
+ impossible version ranges. These rules are:
 
 - Constraints are sorted by version. The canonical ordering is the
-version order. The ordering of **version-constraints** components
-is not significant but this sort order is needed when checking
-if a version is contained within a range.
+version order. The ordering of **constraints** components
+is significant for validity: tools shall report an error for
+non-canonical ordering.
 - Versions are unique. Each version must be unique in a range
-and can occur only once in any **version-constraints** component of
+and can occur only once in any **constraints** component of
 VERS, regardless of the **comparators**. Tools shall report an
 error for duplicated versions.
 - There can be only one asterisk: if used, '\*' must occur only once and alone
@@ -177,22 +179,23 @@ constraint.
 
 Ignoring all constraints with the '!=' **comparator**:
 
-- A constraint using the '=' **comparator** must be followed only by a constraint
-with one of   '=', '>', or '>=' as the **comparator** or no constraint.
+- A constraint using the '=' **comparator** must be followed only by a 
+constraint with one of   '=', '>', or '>=' as the **comparator** or no 
+constraint.
 
 Ignoring all constraints with a '=' or '!=' **comparator**, the sequence
 of constraints must be an alternation of Greater-than and Lesser-than
 **comparators**:
-- A constraint using '\<' and '\<=' must be followed by one of '>' or '>='
+- A constraint using '\<' and '\<=' must be followed by one of '>' or '>=' 
 (or no constraint).
-- A constraint using '>' and '>=' must be followed by one of '\<' or '\<='
-(or no constraint).
+- A constraint using '>' and '>=' must be followed by one of '\<' or '\<=' 
+(or no constraint). 
 
 Tools must report an error for such invalid ranges.
 
 ### Using version range specifiers
 
-The primary VERS use case is to test if a version is within a range.
+The primary VERS use case is to test if a version is within a range. 
 A version is within a version range if it falls within any of the intervals
 defined by a range. Otherwise, the version is outside of the version
 range.
@@ -206,7 +209,7 @@ Some important use cases derived from this include:
   outside the range. For example, given a vulnerability and the VERS
   describing the vulnerable versions of a package, this process is
   used to determine if an existing package version is vulnerable.
-
+  
 - **Select one of several versions that are within a range.**
 
   In this case, with the input of several versions that are within a
@@ -216,20 +219,20 @@ Some important use cases derived from this include:
   the version range constraints of all of the dependencies. This
   usually requires deploying heuristics and algorithms (possibly
   as complex as SAT solvers) that are ecosystem- and tool-specific
-  and outside of the scope for this specification. VERS could
-  be used in tandem with PURL to provide an input to this dependencies
+  and outside of the scope of this specification. VERS could
+  be used in tandem with PURL to provide an input to this dependency
   resolution process.
 
 ### Examples
 
 For example, to define a set of versions that contains either version
 "1.2.3", or any versions greater than or equal to "2.0.0" but less than
-"5.0.0" using the "node-semver" version scheme for the "npm" PURL **type**,
+"5.0.0" using the "node-semver" version scheme for the "npm" PURL **type**, 
 the version range specifier will be:
 
     vers:npm/1.2.3|>=2.0.0|<5.0.0
 
-This is an example of how to read a set of **version-constraints** in version
+This is an example of how to read a set of **constraints** in version 
 order from left to right to determine the versions that are included in a
 VERS notation. In this case you process in order:
 - Include a single version "1.2.3"
@@ -248,17 +251,17 @@ a `package.json` manifest file the version range specification is:
     vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1
 
 #### A complex statement about a vulnerability in a "maven" package:
-For a "maven" package vulnerability that affects multiple branches,
-each with its own fixed version: `affects Apache TomEE 8.0.0-M1 - 8.0.1,
-Apache TomEE 7.1.0 - 7.1.2, Apache TomEE 7.0.0-M1 - 7.0.7,
+For a "maven" package vulnerability that affects multiple branches, 
+each with its own fixed version: `affects Apache TomEE 8.0.0-M1 - 8.0.1, 
+Apache TomEE 7.1.0 - 7.1.2, Apache TomEE 7.0.0-M1 - 7.0.7, 
 Apache TomEE 1.0.0-beta1 - 1.7.5.`
 
 - A normalized VERS notation is:
 
       vers:maven/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1
-
-- An alternative is to use four VERS notations to cover the same range, using one VERS
-  for each of the vulnerable "branches":
+  
+- An alternative is to use four VERS notations to cover the same range using 
+one VERS for each of the vulnerable "branches":
 
       vers:tomee/>=1.0.0-beta1|<=1.7.5
       vers:tomee/>=7.0.0-M1|<=7.0.7
@@ -268,9 +271,10 @@ Apache TomEE 1.0.0-beta1 - 1.7.5.`
   See also: https://repo1.maven.org/maven2/org/apache/tomee/apache-tomee/
 
 #### Converting RubyGems custom syntax for dependencies:
-Note how the pessimistic version constraint is expanded for the RubyGems dependency
-expression: `'library', '~>2.2.0', '!=2.2.1', '<2.3.0'`
+Note how the pessimistic version constraint is expanded for the RubyGems 
+dependency expression: `'library', '~>2.2.0', '!=2.2.1', '<2.3.0'`
 
 - The VERS notation is:
 
       vers:gem/>=2.2.0|!=2.2.1|<2.3.0
+

--- a/website/docs/vers/tests.md
+++ b/website/docs/vers/tests.md
@@ -16,8 +16,8 @@ conform to the VERS specification for tool functions such as:
 - validate a VERS string
 - parse a VERS string to determine if a version is contained within a range
 
-The test files are available at: [vers-spec/tests/](https://github.com/package-url/vers-spec/tree/main/tests). Each test file is in JSON format with
-a naming convention based on: `<version-scheme>_<range OR version>_<test-type>_test.json.`
+The test files are available at: [vers-spec/tests/](https://github.com/package-url/vers-spec/tree/main/tests). 
+Each test file is in JSON format with a naming convention based on: `<version-scheme>_<range OR version>_<test-type>_test.json.`
 
 Two key properties in the VERS test JSON Schema are:
 - Test groups
@@ -35,15 +35,17 @@ permissive than base tests. They may correct some errors.
 There are nine VERS test types:
 - **build**: A test to build a canonical VERS string from decoded VERS
 components.
-- **comparison**: A test to sort an input version string array using the applicable **version-scheme** rules.
+- **comparison**: A test to sort an input version string array using the 
+applicable VERS **type** rules.
 - **containment**: A test to determine whether a bare version string is
 contained within the range of a VERS string.
 - **equality**: A test to check if two input versions strings are equal using
-the applicable **version-scheme** rules.
-- **from_native**: A test to construct a canonical VERS string from a native ecosystem data source.
+the applicable VERS **type** rules.
+- **from_native**: A test to construct a canonical VERS string from a native 
+ecosystem data source.
 - **invert**: A test to invert a VERS string into a canonical VERS string.
 - **merge**: A test to merge an array of VERS strings into a canonical VERS string.
-- **parse**: A test to parse a VERS string into a decoded **version-scheme**
-and a **version-constraints** list.
+- **parse**: A test to parse a VERS string into a decoded VERS **type**
+and a **constraints** list.
 - **roundtrip**: A test to parse a VERS input string and build a canonical
 VERS output string.

--- a/website/docs/vers/vers-types.md
+++ b/website/docs/vers/vers-types.md
@@ -1,37 +1,36 @@
 ---
-id: version-schemes
-title: Version schemes
-sidebar_label: Version schemes
+id: vers-types
+title: VERS types
+sidebar_label: VERS types
 hide_table_of_contents: false
 ---
-
-# Version schemes
+# VERS types
 
 There is a very wide range of software version schemes. For the development of
-the VERS specification, we are focused on three types of version schemes:
+the VERS specification, we are focused on three categories of VERS **types**:
 
-- Package ecosystem version schemes: Our initial focus is to define VERS
-**version-schemes** for packages with a registered [PURL (Package-URL) **type**](/docs/purl/purl-types#registered-purl-types).
-- Vulnerability system version range schemes: The focus here is on the
-definition of version ranges for major vulnerability databases, such as the
-[NVD](https://nvd.nist.gov/) and the [OSV](https://osv.dev/), to identify
-which software package or component versions are impacted by a reported
+- Package ecosystem VERS **types**: Our initial focus is to define VERS 
+**types** for packages with a registered [PURL (Package-URL) **type**](https://package-url.github.io/www.packageurl.org/docs/purl/purl-spec-purl-types#registered-purl-types).
+- Vulnerability system VERS **types**: The focus here is on the 
+definition of version ranges for major vulnerability databases, such as the 
+[NVD](https://nvd.nist.gov/) and the [OSV](https://osv.dev/), to identify 
+which software package or component versions are impacted by a reported 
 vulnerability.
-- Generic version schemes: These version schemes should be reserved for
+- Generic VERS **types** : These version schemes should be reserved for 
 special cases.
 
-## Package ecosystem version schemes
-Most software package ecosystems have a version-scheme. Some variation of
-[SemVer](https://semver.org/) is probably the most popular approach to
-structure version strings, but it does not provide a way to express version
+## Package ecosystem VERS types
+Most software package ecosystems have a version scheme. Some variation of 
+[SemVer](https://semver.org/) is probably the most popular approach to 
+structure version strings, but it does not provide a way to express version 
 ranges.
 
-The following table lists versioning schemes for some common registered [PURL
-(Package-URL) **types**](/docs/purl/purl-types#registered-purl-types). If there is a registered PURL
-**type** for a package ecosystem, the PURL type will also be the name for the
-VERS **version-scheme**.
+The following table lists versioning schemes for some common registered [PURL 
+(Package-URL) **types**](https://package-url.github.io/www.packageurl.org/docs/purl/purl-spec-purl-types#registered-purl-types). 
+If there is a registered PURL **type** for a package ecosystem, the PURL type 
+will also be the name for the VERS **type**.
 
-| PURL type | Description   | Reference URL      |
+| type | Description   | Reference URL      |            
 | --------- | --------------| ------------------ |
 | alpm   | Arch Linux uses its own simplified notation for its PKGBUILD depends array and uses a modified RPM version comparison. | https://wiki.archlinux.org/title/PKGBUILD#Dependencies|
 | apk    | Alpine Linux uses comparison operators similar to VERS.              | https://gitlab.alpinelinux.org/alpine/apk-tools/-/blob/master/src/version.c|
@@ -39,7 +38,7 @@ VERS **version-scheme**.
 | composer  | Composer for PHP  | https://getcomposer.org/doc/articles/versions.md |
 | cpan      | Perl CPAN defines its own version range notation similar to VERS with two-segment versions. |  https://metacpan.org/pod/CPAN::Meta::Spec#VERSION-NUMBERS <br> https://perlmaven.com/how-to-compare-version-numbers-in-perl-and-for-cpan-modules  |
 | dart | The Dart pub versioning scheme is similar to "node-semver". Version resolution uses its own algorithm. | https://dart.dev/tools/pub/versioning |
-| deb       | Debian and Ubuntu use their own notation and are known for their use of "epochs" to disambiguate versions. They both use the comparators: '<<', '<=', '=', '>=' and '>>'| https://www.debian.org/doc/debian-policy/ch-relationships.html |
+| deb       | Debian and Ubuntu use their own native notation and are known for their use of "epochs" to disambiguate versions. Their native comparators are '<<', '<=', '=', '>=' and '>>'. As '<<' and '>>' are not allowed as comparators in VERS, tools should translate '<<' to '<' and '>>' to '>' when converting Debian ranges. | https://www.debian.org/doc/debian-policy/ch-relationships.html |
 | gem       | RubyGems strongly suggests using SemVer for versioning but does not enforce it. As a result some popular packages do not use strict Semver. RubyGems uses their own notation for version ranges which is similar to the "node-semver" notation with some subtle differences. | https://guides.rubygems.org/patterns/#semantic-versioning |
 | golang    | Go modules use SemVer versions with a specific minimum version resolution algorithm.   | https://golang.org/ref/mod#versions|
 | hackage | The Haskell Package Versioning Policy provides a notation similar to VERS based on a modified SemVer with extra notations such as star and caret.   | https://pvp.haskell.org/  |
@@ -49,9 +48,9 @@ VERS **version-scheme**.
 | pypi      | Python uses its own version and version range notation with notable peculiarities for how pre-release and post-release suffixes are used. | https://www.python.org/dev/peps/pep-0440/   |
 | rpm       | RPM distros use their own range notation and they use "epochs" like Debian. | https://rpm-software-management.github.io/rpm/manual/dependencies.html |
 
-## Vulnerability database version schemes
+## Vulnerability database VERS types
 
-### CPE/NVD version schemes
+### CPE/NVD VERS type
 
 - Version 5 of the CVE JSON data format defines version ranges with a
   **starting version**, a **versionType**, and an upper limit for the
@@ -61,54 +60,54 @@ VERS **version-scheme**.
   of the comparison (less-than) operation on versions, which is required
   to understand the range itself".
     A **versionType** resembles closely the Package-URL package **type**.
-  See: https://github.com/CVEProject/cve-schema/blob/main/schema/docs/versions.md#versions-and-version-ranges
+  See: https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0.schema#L303
 
 - The NVD defines CPE ranges as lists of version start and end versions
   either including or excluding the start or end version. NVD also provides
   an enumeration of the available ranges as a daily feed.
   See: https://nvd.nist.gov/vuln/data-feeds#cpeMatch
 
-### OSV version scheme
+### OSV VERS type
 - The OSSF OSV schema defines vulnerable ranges with version events using
   "introduced", "fixed" and "limit" fields and an optional enumeration of all
   versions in these ranges, except for "semver"-based versions. A range may be
   ecosystem-specific based on a provided package "ecosystem" value
-  that resembles the Package-URL package "type". See: https://ossf.github.io/osv-schema/
+  that resembles the Package-URL package **type**. See: https://ossf.github.io/osv-schema/ 
 
-## Generic version schemes
+## Generic VERS types
 
-These are generic schemes, to be used sparingly for special cases:
+These are generic VERS **types**, to be used sparingly for special cases:
 
-- **all**: a generic versioning scheme for a range containing all
-versions. 'vers:all/*' is the only valid VERS form for this scheme.
-- **datetime**: a generic scheme that uses a timestamp for comparison.
+- **all**: a generic VERS **type** for a range containing all
+versions. 'vers:all/*' is the only valid VERS form for this **type**.
+- **datetime**: a generic VERS **type** that uses a timestamp for comparison.
 The timestamp must adhere to RFC3339, section 5.6. See
 https://www.rfc-editor.org/rfc/rfc3339#section-5.6.
-- **generic**: a generic version comparison algorithm (which will be
-specified later, likely based on a split on any wholly alpha or
+- **generic**: a generic VERS **type** using a comparison algorithm which 
+ will be specified later, likely based on a split on any wholly alpha or
  wholly numeric segments and dealing with digit and string
- comparisons, similar to libversion).
-- **intdot**: a generic versioning scheme that allows version
+ comparisons, similar to libversion.
+- **intdot**: a generic VERS **type** that allows version
 components to be specified as integers separated by dots, e.g.
 '10.234.5.12'. Versions specified in this scheme consist of ASCII
 digits only, formatted with only non-negative integers, and ignoring
 leading zeros. Interpretation of the version should stop at the
 first character that is not a digit or a dot.
-- **lexicographic**: a generic versioning scheme that compares
+- **lexicographic**: a generic VERS **type** that compares
 versions based on lexicographic order, interpreted as UTF-8. Strings
 should be compared bytewise as unsigned bytes without normalization.
 UTF-8 encoding is defined in https://datatracker.ietf.org/doc/html/rfc3629.
-- **none**: a generic versioning scheme for a range containing no
+- **none**: a generic VERS **type**for a range containing no
 versions. 'vers:none/*' is the only valid VERS form for this scheme.
-- **semver**: a generic scheme that uses the same syntax as SemVer.
+- **semver**: a VERS **type** that uses the same syntax as SemVer.
 It follows the MAJOR.MINOR.PATCH format and is defined in the
 Semantic Versioning Specification 2.0.0. See
 https://semver.org/spec/v2.0.0.html.
 
 ## Version comparison conventions
 
-The way two versions are compared as equal, less than or greater than is
-closely related to version schemes.
+The way two versions are compared as equal, less than or greater than is 
+closely related to VERS **types**.
 
 - Each package ecosystem may have evolved its own specific version
   string conventions, semantics and comparison procedure. For instance,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -90,7 +90,7 @@ const config = {
                             'vers/specification-folder.md': `https://github.com/package-url/www.packageurl.org/blob/main/website/docs/${docPath}`,
                             'vers/specification.md': `https://github.com/package-url/vers-spec/blob/main/docs/standard/specification.md`,
                             'vers/tests.md': `https://github.com/package-url/vers-spec/blob/main/docs/tests.md`,
-                            'vers/version-schemes.md': `https://github.com/package-url/vers-spec/blob/main/docs/version-schemes.md`,
+                            'vers/vers-types.md': `https://github.com/package-url/vers-spec/blob/main/docs/vers-types.md`,
 
                             // "Particpate"
                             'participate/contribute.md': `https://github.com/package-url/www.packageurl.org/blob/main/website/docs/${docPath}`,
@@ -187,8 +187,8 @@ const config = {
                                 label: 'VERS test overview',
                             },
                             {
-                                to: '/docs/vers/version-schemes',
-                                label: 'Version schemes',
+                                to: '/docs/vers/vers-types',
+                                label: 'VERS types',
                             },
                             {
                                 to: '/docs/vers/schemas',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -37,7 +37,7 @@ const sidebars = {
             ],
         },
         'vers/tests',
-        'vers/version-schemes',
+        'vers/vers-types',
         'vers/schemas',
         'vers/faq',
     ],


### PR DESCRIPTION
Applied updates from vers-spec for:
- renaming the VERS components 
   - version-scheme to type
   - version-constraints to constraints
- changing version-schemes to vers-types.