### PR TITLE
Update spec docs from vers-spec

### DIFF
--- a/website/docs/vers/how-to-parse.md
+++ b/website/docs/vers/how-to-parse.md
@@ -11,56 +11,63 @@ hide_table_of_contents: false
 
 To parse a VERS string:
 
-- Remove all spaces and tabs.
+- Check that the VERS string is canonical.
+- Tools shall report an error if the VERS string contains any ASCII whitespace
+  character (including SPACE, TAB, and LF).
 - Start from left, and split once on colon ':'.
 - The left hand side is the URI-scheme that shall be lowercase.
     - Tools shall validate that the URI-scheme value is 'vers'.
 - The right hand side is the specifier.
 - Split the specifier from left once on a slash '/'.
-- The left hand side is the **version-scheme** that shall be
-  lowercase. Tools should validate that the **version-scheme** is a
-  known scheme.
-- The right hand side is a list of one or more constraints. Tools
-  validate that this **version-constraints** string is not empty
+- The left hand side is the **type** that shall be lowercase. Tools should 
+   validate that the **type** is a known **type**.
+- The right hand side is a list of one or more constraints. Tools 
+  validate that this **constraints** string is not empty
   ignoring spaces.
-- If the string is equal to '\*', the **version-constraints** value is
+- If the string is equal to '\*', the **constraints** value is
  '*'. Parsing is done and no further processing is needed for this VERS.
   A tool should report an error if there are characters other than '\*'.
-- Strip leading and trailing pipes '|' from the constraints string.
+- Tools shall report an error if the constraints string has a leading or
+  trailing pipe '|'.
 - Split the constraints on pipe '|'. The result is a list of
-  **version-constraints** strings. Consecutive pipes shall be treated as one.
-  Leading and trailing pipes are ignored.
-- For each **version-constraints** string:
-    - Determine if the **version-constraints** string starts with a valid
-      **comparator**:  '>=', '<=', '!=', '<', '>', '=', or '*'.
-    - If the **version-constraints** string does not start with a valid
-      **comparator**, then report an error.
-    - If the **comparator** is one of: '>=', '<=', '!=', '<', or '>', then remove
-      the comparator from **version-constraints** string start. The remaining
-      string is the version.
-    - Otherwise the version is the full **version-constraints** string
-      (which implies an equality comparator of '=').
+  **constraints** strings. Tools shall report an error if consecutive
+  pipes are present.
+- For each **constraints** string:
+    - Determine if the **constraints** string starts with one of the
+      two-character **comparators** ('>=', '<=', '!=') or one-character
+      **comparators** ('<', '>'):
+        - If it starts with '>=', then the comparator is '>='.
+        - If it starts with '<=', then the comparator is '<='.
+        - If it starts with '!=', then the comparator is '!='.
+        - If it starts with '<', then the comparator is '<'.
+        - If it starts with '>', then the comparator is '>'.
+        - Remove the comparator from **constraints** string
+          start. The remaining string is the version.
+    - Otherwise the version is the full **constraints** string
+      (which implies an equality comparator of '=')
     - Tools should validate and report an error if the version is
       empty.
     - If the version contains a percent '%' character, apply URL
       quoting rules to unquote this string.
-    - Append the parsed **version-constraints** strings to the
-      constraints list.
+    - Append the parsed **constraints** strings to the constraints list.
 
 Finally:
 
-- The results are the **version-scheme** and the list of
-  **version-constraints** strings.
+- The results are the **type** and the list of **constraints** strings.
 
-Tools should optionally validate and simplify the list of
-**version-contraints** strings once parsing is complete by:
+Tools should optionally validate and simplify the list of **constraints** 
+strings once parsing is complete by:
 
 - Sorting and validating the list of constraints
-- Simplifying the list of constraints
 
-### Version-constraints simplification
+Tools shall report an error if the parsed constraints are non-canonical,
+including non-canonical ordering, duplicate versions, or invalid comparator
+sequences. Tools should not auto-correct non-canonical input during parsing.
 
-Tools can simplify a list of **version-constraints** strings using the following approach.
+### Constraints simplification
+
+Tools can simplify a list of **constraints** strings using the following 
+ approach.
 
 These pairs of contiguous constraints with these **comparators** are valid:
 
@@ -68,7 +75,8 @@ These pairs of contiguous constraints with these **comparators** are valid:
 - '=', '<', or '<=' followed by '=', '!=', '>', or '>='
 - '>', or '>=' followed by '!=', '<', or '<='
 
-These pairs of contiguous constraints with these **comparators** are redundant and invalid (ignoring any instances of '!=' because they can show up anywhere):
+These pairs of contiguous constraints with these **comparators** are redundant
+ and invalid (ignoring any instances of '!=' because they can show up anywhere):
 
 - '=', '<' or '<=' followed by '<' or '<=:' this is the same as '<' or '<='
 - '>' or '>=' followed by '=', '>' or '>=:' this is the same as '>' or '>='
@@ -118,7 +126,7 @@ To check if a "tested version" is contained within a version range:
 
 - Start from a parsed version range specifier with:
 
-    - a **version-scheme**
+    - a VERS **type**
     - a list of constraints of **comparator** and **version**, sorted by
       version and where each version occurs only once in any
       constraint.
@@ -170,12 +178,11 @@ To check if a "tested version" is contained within a version range:
 
 ### Notes and caveats
 
-- Comparing versions from VERS notations with a different
-  **version-scheme** is an error. Even though there may be some
-  similarities between the "semver" version for an "npm" and the
-  "deb" version for its Debian packaging, the way versions are
-  compared for each **version-scheme** may be different. Tools should
-  report an error in this case.
+- Comparing versions from VERS notations with a different **type** is an 
+error. Even though there may be some similarities between the "semver" version
+for an "npm" and the "deb" version for its Debian packaging, the way versions 
+are compared for each **type** may be different. Tools should report an error 
+in this case.
 - All references to sorting or ordering of version constraints mean
-  sorting by version. And sorting by versions always implies using the
-  **version-scheme**-specified version comparison and ordering.
+  sorting by version. And sorting by versions always implies using the VERS
+  **type**-specified version comparison and ordering.

--- a/website/docs/vers/specification.md
+++ b/website/docs/vers/specification.md
@@ -5,12 +5,12 @@ sidebar_label: Core Specification
 hide_table_of_contents: false
 ---
 
-# Core specification
+# VERS specification
 
-VERS stands for "VErsion Range Specifier. A VERS is an ASCII URI string composed of
-three components:
+VERS stands for "VErsion Range Specifier. A VERS is an ASCII URI string 
+composed of three components:
 
-    scheme:version-scheme/version-constraints|
+    scheme:type/constraints|
 
 Components are separated by a specific character for unambiguous parsing.
 
@@ -19,15 +19,14 @@ Components are separated by a specific character for unambiguous parsing.
 | Component           | Requirement | Description|
 | ------------------- | ----------- |:------------------------------------------------------ |
 | scheme              | Required    | The URL scheme with the constant value of "vers". |
-| version-scheme      | Required    | The version specification or "scheme" such as "semver", "npm", "deb", etc. |
-| version-constraints | Required    | Version constraints may be repeated as many times as needed to accurately reflect the intended range. The separator between version-constraints is a single pipe '\|'. |
+| type                | Required    | The version specification type such as "semver", "npm", "deb", etc. |
+| constraints         | Required    | Version constraints may be repeated as many times as needed to accurately reflect the intended range. The separator between version-constraints is a single pipe '\|'. |
 
 ## Separator characters
 This is how each of the Separator Characters is used:
-- ':' (colon) is the separator between **scheme** and **version-scheme**
-- '/' (slash) is the separator between **version-scheme** and
-**version-constraints**
-- '|' (pipe) is the separator between **version-constraints**
+- ':' (colon) is the separator between **scheme** and **type**
+- '/' (slash) is the separator between **type** and **constraints**
+- '|' (pipe) is the separator between **constraints**
 
 **Example 1 (Informative): npm**
 
@@ -39,7 +38,7 @@ This is how each of the Separator Characters is used:
 
 ## A VERS is a URI scheme
 
-A VERS is a valid URI scheme that conforms to URI definitions or
+A VERS is a valid URI scheme that conforms to URI definitions or 
 specifications at: - https://tools.ietf.org/html/rfc3986
 
 ## VERS components
@@ -48,48 +47,48 @@ specifications at: - https://tools.ietf.org/html/rfc3986
 - The **scheme** is a constant with the value "vers".
 - The **scheme** shall be followed by an unencoded colon ':'.
 
-### Version-scheme
-- The **version-scheme** shall be composed only of ASCII letters and numbers,
+### Type
+- The **type** shall be composed only of ASCII letters and numbers,
   period '.', and dash '-'.
-- The **version-scheme** shall start with an ASCII letter.
-- The **version-scheme** shall not be percent-encoded.
-- The **version-scheme** is case insensitive. The canonical form is lowercase.
-- The **version-scheme** shall be followed by a slash '/'.
+- The **type** shall start with an ASCII letter.
+- The **type** shall not be percent-encoded.
+- The **type** is case insensitive. The canonical form is lowercase.
+- The **type** shall be followed by a slash '/'.
 
-A **version-scheme** defines:
+A **type** defines:
 
-- the specific notation and conventions used for a version string encoded in
-this scheme
-- how two versions are compared to determine if a version is inside or
+- the specific notation and conventions used for a version string encoded 
+according to this type
+- how two versions are compared to determine if a version is inside or 
 outside a range
-- how a version-scheme-specific range notation can be transformed into VERS
+- how a type-specific range notation can be transformed into VERS 
 notation
 
-A **version-scheme** also defines:
+A **type** also defines:
 - how to compare two version strings using **comparators**
 - the structure (if any) of a **version** string such as "1.2.3". For
-example, the "semver" specification for version numbers defines a version as
-composed primarily of three dot-separated numeric segments named "major",
+example, the "semver" specification for version numbers defines a version as 
+composed primarily of three dot-separated numeric segments named "major", 
 "minor" and "patch".
 
-By convention a **version-scheme** should be the same as the
+By convention a **type** should be the same as the
 PURL **type** for a given package ecosystem. It is, however, allowed to
-define a **version-scheme** that does not match an existing PURL **type**
+define a **type** that does not match an existing PURL **type**
 such as a scheme that applies to a single package or project.
 
-### Version-constraints
-- The **version-constraints** component shall be preceded by an unencoded
+### constraints
+- The **constraints** component shall be preceded by an unencoded
 '/' slash separator when not empty.
-- Each instance of the **version-constraints** component is composed of either
+- Each instance of the **constraints** component is composed of either
 a single **version** as in '1.2.3' or the combination of a **comparator** and
 a **version** as in '>=2.0.0'.
 - A **comparator** always precedes the **version** with no characters allowed
 between the **comparator** and the **version**
-- Multiple **version-constraints** strings shall be separated by an unencoded
+- Multiple **constraints** strings shall be separated by an unencoded
 pipe '|'. The pipe "|" has no special meaning other than being a separator.
 
 #### Comparator characters
-A **comparator** is composed of these ASCII characters:
+A **comparator** is composed of these ASCII characters: 
 - the Equals character: '=' (equals, '=')
 - the Not Equals character: '!' (exclamation mark, '!')
 - the Greater Than character: '>' (greater than, '>')
@@ -103,7 +102,7 @@ the provided version.
 equal to the provided version and it must be excluded from the range.
 For example: '!=1.2.3' means that version   "1.2.3" is excluded.
 - '<' is the Less-than **comparator**. This includes all versions less than
-the provided version.
+the provided version. 
 - '<=': is the Less-or-equal **comparator**. This includes all versions less
 than or equal to the provided version. For example '<=1.2.3' means
 less than or equal to "1.2.3".
@@ -120,49 +119,52 @@ Debian package. This includes past, current and possible future versions.
 #### Version strings
 A Version is an ASCII string.
 
-A single **version** in a **version-constraints** string means that a version
-equal to this version satisfies the range specification. Equality is based on
+A single **version** in a **constraints** string means that a version 
+equal to this version satisfies the range specification. Equality is based on 
 the equality of two normalized version strings according to the applicable
-**version-scheme**. For most schemes, this is a simple string equality. A
-**version-scheme** may, however, define normalization and other rules for
+**type**. For most schemes, this is a simple string equality. A 
+**type** may, however, define normalization and other rules for 
 equality such as the "pypi" rules from PEP 440.
 
-A package version satisfies a set of **version-constraints** if it is
-contained within any of the intervals defined by the **version-constraints**.
+A package version satisfies a set of **constraints** if it is 
+contained within any of the intervals defined by the **constraints**.
 
 ## Normalized, canonical representation and validation
 
 VERS construction and validation rules are designed such that a VERS is
 easy to read and understand by humans and straightforward to process
-with tools. The rules are designed to prevent the creation of empty or
+with tools. The rules are designed to prevent the creation of empty or 
 impossible version ranges.
 
-- Spaces are not significant and are removed in a canonical form. For
-example '|<1.2.3|>=2.0|' and '|< 1 . 2 . 3 | > = 2 . 0 |' are equivalent.
+- A VERS string shall already be in canonical form. Non-canonical 
+(unnormalized) forms are invalid and tools shall report an error instead of 
+normalizing them automatically.
 - A version range specifier contains only printable ASCII letters,
 digits and punctuation.
-- The VERS **scheme** and **version-scheme** are always lowercase as in
+- ASCII whitespace is not permitted in a VERS string. Tools shall report an
+error if any Whitespace character, for example SPACE (0x20), TAB (0x09), or 
+LF (0x0A), is used.
+- The VERS **scheme** and **type** are always lowercase as in
 'vers:npm'.
-- Versions are case-sensitive. A **version-scheme** may specify
+- Versions are case-sensitive. A **type** may specify
 its own case sensitivity.
-- If a version in a **version-constraints** string contains **separator** or
+- If a version in a **constraints** string contains **separator** or
 **comparator** characters (i.e., '>', '<', '=', '!', '*', '|'), the version
 shall be quoted using the URL quoting rules. This should be rare in practice.
 
-The list of **version-constraints** strings for a range are like a set of
-signposts in the version timeline of a package. The separators do not mean
-"and" or "or". They are separators in a sequence of **version-constraints**.
+The list of **constraints** strings for a range are like a set of 
+signposts in the version timeline of a package. The separators do not mean 
+"and" or "or". They are separators in a sequence of **constraints**.
 
-With a few simple validation
-rules, we can avoid the creation of most empty or impossible version ranges.
-These rules are:
+With a few simple validation rules, we can avoid the creation of most empty or
+ impossible version ranges. These rules are:
 
 - Constraints are sorted by version. The canonical ordering is the
-version order. The ordering of **version-constraints** components
-is not significant but this sort order is needed when checking
-if a version is contained within a range.
+version order. The ordering of **constraints** components
+is significant for validity: tools shall report an error for
+non-canonical ordering.
 - Versions are unique. Each version must be unique in a range
-and can occur only once in any **version-constraints** component of
+and can occur only once in any **constraints** component of
 VERS, regardless of the **comparators**. Tools shall report an
 error for duplicated versions.
 - There can be only one asterisk: if used, '\*' must occur only once and alone
@@ -177,22 +179,23 @@ constraint.
 
 Ignoring all constraints with the '!=' **comparator**:
 
-- A constraint using the '=' **comparator** must be followed only by a constraint
-with one of   '=', '>', or '>=' as the **comparator** or no constraint.
+- A constraint using the '=' **comparator** must be followed only by a 
+constraint with one of   '=', '>', or '>=' as the **comparator** or no 
+constraint.
 
 Ignoring all constraints with a '=' or '!=' **comparator**, the sequence
 of constraints must be an alternation of Greater-than and Lesser-than
 **comparators**:
-- A constraint using '\<' and '\<=' must be followed by one of '>' or '>='
+- A constraint using '\<' and '\<=' must be followed by one of '>' or '>=' 
 (or no constraint).
-- A constraint using '>' and '>=' must be followed by one of '\<' or '\<='
-(or no constraint).
+- A constraint using '>' and '>=' must be followed by one of '\<' or '\<=' 
+(or no constraint). 
 
 Tools must report an error for such invalid ranges.
 
 ### Using version range specifiers
 
-The primary VERS use case is to test if a version is within a range.
+The primary VERS use case is to test if a version is within a range. 
 A version is within a version range if it falls within any of the intervals
 defined by a range. Otherwise, the version is outside of the version
 range.
@@ -206,7 +209,7 @@ Some important use cases derived from this include:
   outside the range. For example, given a vulnerability and the VERS
   describing the vulnerable versions of a package, this process is
   used to determine if an existing package version is vulnerable.
-
+  
 - **Select one of several versions that are within a range.**
 
   In this case, with the input of several versions that are within a
@@ -216,20 +219,20 @@ Some important use cases derived from this include:
   the version range constraints of all of the dependencies. This
   usually requires deploying heuristics and algorithms (possibly
   as complex as SAT solvers) that are ecosystem- and tool-specific
-  and outside of the scope for this specification. VERS could
-  be used in tandem with PURL to provide an input to this dependencies
+  and outside of the scope of this specification. VERS could
+  be used in tandem with PURL to provide an input to this dependency
   resolution process.
 
 ### Examples
 
 For example, to define a set of versions that contains either version
 "1.2.3", or any versions greater than or equal to "2.0.0" but less than
-"5.0.0" using the "node-semver" version scheme for the "npm" PURL **type**,
+"5.0.0" using the "node-semver" version scheme for the "npm" PURL **type**, 
 the version range specifier will be:
 
     vers:npm/1.2.3|>=2.0.0|<5.0.0
 
-This is an example of how to read a set of **version-constraints** in version
+This is an example of how to read a set of **constraints** in version 
 order from left to right to determine the versions that are included in a
 VERS notation. In this case you process in order:
 - Include a single version "1.2.3"
@@ -248,17 +251,17 @@ a `package.json` manifest file the version range specification is:
     vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1
 
 #### A complex statement about a vulnerability in a "maven" package:
-For a "maven" package vulnerability that affects multiple branches,
-each with its own fixed version: `affects Apache TomEE 8.0.0-M1 - 8.0.1,
-Apache TomEE 7.1.0 - 7.1.2, Apache TomEE 7.0.0-M1 - 7.0.7,
+For a "maven" package vulnerability that affects multiple branches, 
+each with its own fixed version: `affects Apache TomEE 8.0.0-M1 - 8.0.1, 
+Apache TomEE 7.1.0 - 7.1.2, Apache TomEE 7.0.0-M1 - 7.0.7, 
 Apache TomEE 1.0.0-beta1 - 1.7.5.`
 
 - A normalized VERS notation is:
 
       vers:maven/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1
-
-- An alternative is to use four VERS notations to cover the same range, using one VERS
-  for each of the vulnerable "branches":
+  
+- An alternative is to use four VERS notations to cover the same range using 
+one VERS for each of the vulnerable "branches":
 
       vers:tomee/>=1.0.0-beta1|<=1.7.5
       vers:tomee/>=7.0.0-M1|<=7.0.7
@@ -268,8 +271,8 @@ Apache TomEE 1.0.0-beta1 - 1.7.5.`
   See also: https://repo1.maven.org/maven2/org/apache/tomee/apache-tomee/
 
 #### Converting RubyGems custom syntax for dependencies:
-Note how the pessimistic version constraint is expanded for the RubyGems dependency
-expression: `'library', '~>2.2.0', '!=2.2.1', '<2.3.0'`
+Note how the pessimistic version constraint is expanded for the RubyGems 
+dependency expression: `'library', '~>2.2.0', '!=2.2.1', '<2.3.0'`
 
 - The VERS notation is:
 

--- a/website/docs/vers/specification.md
+++ b/website/docs/vers/specification.md
@@ -20,7 +20,7 @@ Components are separated by a specific character for unambiguous parsing.
 | ------------------- | ----------- |:------------------------------------------------------ |
 | scheme              | Required    | The URL scheme with the constant value of "vers". |
 | type                | Required    | The version specification type such as "semver", "npm", "deb", etc. |
-| constraints         | Required    | Version constraints may be repeated as many times as needed to accurately reflect the intended range. The separator between version-constraints is a single pipe '\|'. |
+| constraints         | Required    | Version constraints may be repeated as many times as needed to accurately reflect the intended range. The separator between constraints is a single pipe '\|'. |
 
 ## Separator characters
 This is how each of the Separator Characters is used:
@@ -58,18 +58,18 @@ specifications at: - https://tools.ietf.org/html/rfc3986
 A **type** defines:
 
 - the specific notation and conventions used for a version string encoded 
-according to this type
+  according to this type
 - how two versions are compared to determine if a version is inside or 
-outside a range
+  outside a range
 - how a type-specific range notation can be transformed into VERS 
-notation
+  notation
 
 A **type** also defines:
 - how to compare two version strings using **comparators**
 - the structure (if any) of a **version** string such as "1.2.3". For
-example, the "semver" specification for version numbers defines a version as 
-composed primarily of three dot-separated numeric segments named "major", 
-"minor" and "patch".
+  example, the "semver" specification for version numbers defines a version as 
+  composed primarily of three dot-separated numeric segments named "major", 
+  "minor" and "patch".
 
 By convention a **type** should be the same as the
 PURL **type** for a given package ecosystem. It is, however, allowed to
@@ -78,14 +78,14 @@ such as a scheme that applies to a single package or project.
 
 ### constraints
 - The **constraints** component shall be preceded by an unencoded
-'/' slash separator when not empty.
+  '/' slash separator when not empty.
 - Each instance of the **constraints** component is composed of either
-a single **version** as in '1.2.3' or the combination of a **comparator** and
-a **version** as in '>=2.0.0'.
+  a single **version** as in '1.2.3' or the combination of a **comparator** 
+  and a **version** as in '>=2.0.0'.
 - A **comparator** always precedes the **version** with no characters allowed
-between the **comparator** and the **version**
+  between the **comparator** and the **version**
 - Multiple **constraints** strings shall be separated by an unencoded
-pipe '|'. The pipe "|" has no special meaning other than being a separator.
+  pipe '|'. The pipe "|" has no special meaning other than being a separator.
 
 #### Comparator characters
 A **comparator** is composed of these ASCII characters: 
@@ -97,29 +97,29 @@ A **comparator** is composed of these ASCII characters:
 
 A **comparator** must be one of the following:
 - '=' is the Equality **comparator**. This means a version must be equal to
-the provided version.
+  the provided version.
 - '!=' is the Inequality **comparator**. This means that a version must not be
-equal to the provided version and it must be excluded from the range.
-For example: '!=1.2.3' means that version   "1.2.3" is excluded.
+  equal to the provided version and it must be excluded from the range.
+  For example: '!=1.2.3' means that version   "1.2.3" is excluded.
 - '<' is the Less-than **comparator**. This includes all versions less than
-the provided version. 
+  the provided version. 
 - '<=': is the Less-or-equal **comparator**. This includes all versions less
-than or equal to the provided version. For example '<=1.2.3' means
-less than or equal to "1.2.3".
+  than or equal to the provided version. For example '<=1.2.3' means
+  less than or equal to "1.2.3".
 - '>' is the Greater-than **comparator**. This includes all versions greater
-than the provided version.
+  than the provided version.
 - '>=' is the Greater-or-equal **comparator**. This includes all versions
-greater than or equal to the provided version. For example '>=1.2.3'
-means greater than or equal to "1.2.3".
+  greater than or equal to the provided version. For example '>=1.2.3'
+  means greater than or equal to "1.2.3".
 - The special Asterisk '\*' **comparator** matches any version. It must be
-used alone and exclusive of any other constraint and must not be followed
-by a version. For example, 'vers:deb/\*' represents all versions of a
-Debian package. This includes past, current and possible future versions.
+  used alone and exclusive of any other constraint and must not be followed
+  by a version. For example, 'vers:deb/\*' represents all versions of a
+  Debian package. This includes past, current and possible future versions.
 
 #### Version strings
 A Version is an ASCII string.
 
-A single **version** in a **constraints** string means that a version 
+A single **version** in a **constraints** string means that a version
 equal to this version satisfies the range specification. Equality is based on 
 the equality of two normalized version strings according to the applicable
 **type**. For most schemes, this is a simple string equality. A 
@@ -137,20 +137,20 @@ with tools. The rules are designed to prevent the creation of empty or
 impossible version ranges.
 
 - A VERS string shall already be in canonical form. Non-canonical 
-(unnormalized) forms are invalid and tools shall report an error instead of 
-normalizing them automatically.
+  (unnormalized) forms are invalid and tools shall report an error instead of 
+  normalizing them automatically.
 - A version range specifier contains only printable ASCII letters,
-digits and punctuation.
+  digits and punctuation.
 - ASCII whitespace is not permitted in a VERS string. Tools shall report an
-error if any Whitespace character, for example SPACE (0x20), TAB (0x09), or 
-LF (0x0A), is used.
+  error if any Whitespace character, for example SPACE (0x20), TAB (0x09), or 
+  LF (0x0A), is used.
 - The VERS **scheme** and **type** are always lowercase as in
-'vers:npm'.
+  'vers:npm'.
 - Versions are case-sensitive. A **type** may specify
-its own case sensitivity.
+  its own case sensitivity.
 - If a version in a **constraints** string contains **separator** or
-**comparator** characters (i.e., '>', '<', '=', '!', '*', '|'), the version
-shall be quoted using the URL quoting rules. This should be rare in practice.
+  **comparator** characters (i.e., '>', '<', '=', '!', '*', '|'), the version
+  shall be quoted using the URL quoting rules. This should be rare in practice.
 
 The list of **constraints** strings for a range are like a set of 
 signposts in the version timeline of a package. The separators do not mean 
@@ -160,36 +160,36 @@ With a few simple validation rules, we can avoid the creation of most empty or
  impossible version ranges. These rules are:
 
 - Constraints are sorted by version. The canonical ordering is the
-version order. The ordering of **constraints** components
-is significant for validity: tools shall report an error for
-non-canonical ordering.
+  version order. The ordering of **constraints** components
+  is significant for validity: tools shall report an error for
+  non-canonical ordering.
 - Versions are unique. Each version must be unique in a range
-and can occur only once in any **constraints** component of
-VERS, regardless of the **comparators**. Tools shall report an
-error for duplicated versions.
+  and can occur only once in any **constraints** component of
+  VERS, regardless of the **comparators**. Tools shall report an
+  error for duplicated versions.
 - There can be only one asterisk: if used, '\*' must occur only once and alone
-in a range, without any other constraint or version.
+  in a range, without any other constraint or version.
 
 Starting from a de-duplicated and sorted list of constraints, these
 extra rules apply to the **comparators** of any two contiguous constraints:
 
 - A constraint using the '!=' **comparator** can be followed by a constraint
-using any **comparator** (any of '=', '!=', '>', '>=', '<', '<=') or no
-constraint.
+  using any **comparator** (any of '=', '!=', '>', '>=', '<', '<=') or no
+  constraint.
 
 Ignoring all constraints with the '!=' **comparator**:
 
 - A constraint using the '=' **comparator** must be followed only by a 
-constraint with one of   '=', '>', or '>=' as the **comparator** or no 
-constraint.
+  constraint with one of   '=', '>', or '>=' as the **comparator** or no 
+  constraint.
 
 Ignoring all constraints with a '=' or '!=' **comparator**, the sequence
 of constraints must be an alternation of Greater-than and Lesser-than
 **comparators**:
 - A constraint using '\<' and '\<=' must be followed by one of '>' or '>=' 
-(or no constraint).
+  (or no constraint).
 - A constraint using '>' and '>=' must be followed by one of '\<' or '\<=' 
-(or no constraint). 
+  (or no constraint). 
 
 Tools must report an error for such invalid ranges.
 


### PR DESCRIPTION
Updated:
- specification.md
- how-to-parse.md
 
to use updated VERS component terminologyL
- 'type' instead of 'version-scheme'
- 'constraints' instead of 'version-constraints'