### PR TITLE
chore: sync docs from purl-spec/vers-spec

### DIFF
--- a/website/docs/vers/test-overview.md
+++ b/website/docs/vers/test-overview.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
 The Version Range Specifier (VERS) specification provides test files to
 support language-neutral testing of VERS implementations. The objectives for
-the VERS test suite is to:
+the VERS test suite are to:
 - Enable tools to demonstrate conformance with the VERS specification as
   defined in the [VERS Core Specification](https://packageurl.org/docs/vers/specification)
   or in registered VERS **type** definitions.


### PR DESCRIPTION
Automated sync of .md files from purl-spec and vers-spec into
website/docs/, per .github/scripts/sync-manifest.json.

The "build" job in A-B-deployment.yml runs on this PR as a check --
confirm it passes before merging. Merging (or enabling auto-merge)
triggers the real deploy.